### PR TITLE
Correct/add documentation items for `data` key

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,8 @@ All children of `etymology_data` have the same list length once split on `;`.
       Integer percentage of survey respondents who recognize and use the word as of [date]. [date] is YYYY-MM format.
   author_verbatim: Definition of the word as written by its original author. Defer to `pu_verbatim` if that is defined.
   pu_verbatim:
-    [language_code]: "Definition of the word in [language_code] as written in the corresponding translation of Toki Pona: The Language of Good."
+    [language_code]:
+      "Definition of the word in [language_code] as written in the corresponding translation of Toki Pona: The Language of Good."
   see_also: A list of words related to [word]. **Split on `,`.**
   commentary: Human-readable extra information about the word, such as historical usage, replacement, or clarifications.
   def:

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Some static files are derived from [ijo Linku](https://github.com/lipu-linku/ijo
 All children of `etymology_data` have the same list length once split on `;`.
 
 ```yml
-[word]: A unique identifier for the word which is often the word, but may have an integer suffix if the word has been coined multiple times.
+[word_id]: A unique identifier for the word which is often the word, but may have an integer suffix if the word has been coined multiple times.
   word: The word as it would be written in toki pona using sitelen Lasina.
   sitelen_pona: A list of latin character strings that convert to all alternates for a given word. Usually identical to [word]; see "akesi".
   ucsur: The unicode codepoint assigned to the word.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,8 @@ Some static files are derived from [ijo Linku](https://github.com/lipu-linku/ijo
 All children of `etymology_data` have the same list length once split on `;`.
 
 ```yml
-[word]:
-  word: Identical to [word].
+[word]: A unique identifier for the word which is often the word, but may have an integer suffix if the word has been coined multiple times.
+  word: The word as it would be written in toki pona using sitelen Lasina.
   sitelen_pona: A list of latin character strings that convert to all alternates for a given word. Usually identical to [word]; see "akesi".
   ucsur: The unicode codepoint assigned to the word.
   sitelen_pona_etymology: Human-readable description of the origin of the sitelen pona.
@@ -78,6 +78,10 @@ All children of `etymology_data` have the same list length once split on `;`.
   recognition:
     [date]:
       Integer percentage of survey respondents who recognize and use the word as of [date]. [date] is YYYY-MM format.
+  author_verbatim: Definition of the word as written by its original author. Defer to `pu_verbatim` if that is defined.
+  pu_verbatim:
+    [language_code]:
+       Definition of the word in [language_code] as written in the corresponding translation of Toki Pona: The Language of Good.
   see_also: A list of words related to [word]. **Split on `,`.**
   commentary: Human-readable extra information about the word, such as historical usage, replacement, or clarifications.
   def:

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ All children of `etymology_data` have the same list length once split on `;`.
       Integer percentage of survey respondents who recognize and use the word as of [date]. [date] is YYYY-MM format.
   author_verbatim: Definition of the word as written by its original author. Defer to `pu_verbatim` if that is defined.
   pu_verbatim:
-    [language_code]:
-       Definition of the word in [language_code] as written in the corresponding translation of Toki Pona\: The Language of Good.
+    [language_code]: "Definition of the word in [language_code] as written in the corresponding translation of Toki Pona: The Language of Good."
   see_also: A list of words related to [word]. **Split on `,`.**
   commentary: Human-readable extra information about the word, such as historical usage, replacement, or clarifications.
   def:

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ All children of `etymology_data` have the same list length once split on `;`.
   author_verbatim: Definition of the word as written by its original author. Defer to `pu_verbatim` if that is defined.
   pu_verbatim:
     [language_code]:
-       Definition of the word in [language_code] as written in the corresponding translation of Toki Pona: The Language of Good.
+       Definition of the word in [language_code] as written in the corresponding translation of Toki Pona\: The Language of Good.
   see_also: A list of words related to [word]. **Split on `,`.**
   commentary: Human-readable extra information about the word, such as historical usage, replacement, or clarifications.
   def:


### PR DESCRIPTION
- `[word_id]` key directly in `data` now correctly indicates that it may have an integer suffix. Renamed for clarity.
- `[word]` key now defined in terms of what it actually contains, instead of its relationship to `[word_id`]
- `pu_verbatim` added
- `author_verbatim` added (not present in `nimi` yet)